### PR TITLE
Update MySQL8 Dockerfile

### DIFF
--- a/dbs/mysql/8/Dockerfile
+++ b/dbs/mysql/8/Dockerfile
@@ -1,16 +1,11 @@
 FROM mysql:8
 
 # We use a standard set of database names and users for our sample images
-ENV MYSQL_DATABASE=sample
-ENV MYSQL_USER=metabase
-ENV MYSQL_PASSWORD=metasample123
-
-# MySQL requires a root user password, we just use the same sample password
-ENV MYSQL_ROOT_PASSWORD=metasample123
+ENV MYSQL_DATABASE=sample MYSQL_USER=metabase MYSQL_PASSWORD=metasample123 MYSQL_ROOT_PASSWORD=metasample123
 
 COPY data/sample_data.sql.gz /docker-entrypoint-initdb.d/sample_data.sql.gz
 
 # Similar to other images, we specify a custom mysql data directory so it can be persisted to an image
-CMD ["--datadir", "/var/lib/mysql-mbsample"]
+CMD ["--datadir", "/var/lib/mysql-mbsample", "--default-authentication-plugin=mysql_native_password"]
 
 # Nope: "--character-set-server", "utf8mb4"


### PR DESCRIPTION
This update should lead to faster container build speed as there are less intermediate containers being built and also it allows to connect to MySQL8 without the key retrieval (it passes the option of using the old mysql native password)