### PR TITLE
Sanity check: download JAR linked from the website and run it

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,0 +1,66 @@
+name: JAR Sanity Check
+
+on:
+  push:
+  schedule:
+    - cron: "0 6 * * *"
+
+jobs:
+
+  download:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 5
+    steps:
+    - name: Get metabase.jar (OSS) from Metabase website
+      run: |
+        curl -o download.html https://www.metabase.com/start/oss/jar.html
+        JAR_DOWNLOAD_URL=`grep 'meta http-equiv="refresh"' download.html | grep -oEi 'https://([a-z0-9A-Z\./]*\.jar)'`
+        echo $JAR_DOWNLOAD_URL > url.txt
+        echo "----- Downloading JAR from $JAR_DOWNLOAD_URL -----"
+        curl -OL $JAR_DOWNLOAD_URL
+        stat ./metabase.jar
+        date | tee timestamp
+    - name: Calculate SHA256 checksum
+      run: sha256sum ./metabase.jar | tee SHA256.sum
+    - name: Upload JAR as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: metabase-jar
+        path: |
+          ./metabase.jar
+          ./url.txt
+          ./timestamp
+          ./SHA256.sum
+
+  check:
+    runs-on: ubuntu-20.04
+    name: check (java ${{ matrix.java-version }})
+    needs: download
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        java-version: [8, 11]
+    steps:
+    - name: Prepare JRE (Java Run-time Environment)
+      uses: actions/setup-java@v1
+      with:
+        java-package: jre
+        java-version: ${{ matrix.java-version }}
+    - run: java -version
+    - uses: actions/download-artifact@v2
+      name: Retrieve previously downloaded JAR
+      with:
+        name: metabase-jar
+    - name: Display when and where it was downloaded
+      run: |
+        cat timestamp
+        cat url.txt
+    - name: Show the checksum
+      run: cat SHA256.sum
+    - name: Launch the JAR (and keep it running)
+      run: java -jar ./metabase.jar &
+    - name: Wait for Metabase to start
+      run: while ! curl -s localhost:3000/api/health; do sleep 1; done
+      timeout-minutes: 3
+    - name: Check API health
+      run: curl -s localhost:3000/api/health

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,7 +1,6 @@
 name: JAR Sanity Check
 
 on:
-  push:
   schedule:
     - cron: "0 6 * * *"
 

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -51,6 +51,8 @@ jobs:
       name: Retrieve previously downloaded JAR
       with:
         name: metabase-jar
+    - name: Reveal its version.properties
+      run: jar xf metabase.jar version.properties && cat version.properties
     - name: Display when and where it was downloaded
       run: |
         cat timestamp


### PR DESCRIPTION
This is intended to run nightly at 11pm PST (6:00 am UTC), but we can definitely tweak it in the future.

It takes < 2 minutes to run and the Action tab will display something like:

![image](https://user-images.githubusercontent.com/7288/124332554-93468c80-db46-11eb-8062-07f36d7422cd.png)

Example of the log of the test:

![image](https://user-images.githubusercontent.com/7288/124335596-a578f880-db4f-11eb-800b-734262fde9ec.png)