### PR TITLE
Sanity check: ensure that the container matches the downloadable JAR

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -31,7 +31,7 @@ jobs:
           ./timestamp
           ./SHA256.sum
 
-  check:
+  check-jar:
     runs-on: ubuntu-20.04
     name: check (java ${{ matrix.java-version }})
     needs: download
@@ -63,5 +63,37 @@ jobs:
     - name: Wait for Metabase to start
       run: while ! curl -s localhost:3000/api/health; do sleep 1; done
       timeout-minutes: 3
+    - name: Check API health
+      run: curl -s localhost:3000/api/health
+
+  check-container:
+    runs-on: ubuntu-20.04
+    name: check container
+    needs: download
+    timeout-minutes: 10
+    steps:
+    - uses: actions/download-artifact@v2
+      name: Retrieve the checksum of previously downloaded JAR
+      with:
+        name: metabase-jar
+        path: download
+    - name: Grab metabase.jar from the Docker image
+      run: |
+        docker run -d --name testrun --entrypoint sleep metabase/metabase 500
+        docker cp testrun:/app/metabase.jar ./metabase.jar
+        docker kill testrun
+    - name: Show its version.properties
+      run: jar xf metabase.jar version.properties && cat version.properties
+    - name: Compare it with the downloaded JAR from the website
+      run: |
+        cp download/SHA256.sum .
+        sha256sum -c SHA256.sum
+    - name: Launch container
+      run: docker run -dp 3000:3000 metabase/metabase
+      timeout-minutes: 5
+    - run: docker ps
+    - name: Wait for Metabase to start
+      run: while ! curl -s localhost:3000/api/health; do sleep 1; done
+      timeout-minutes: 1
     - name: Check API health
       run: curl -s localhost:3000/api/health


### PR DESCRIPTION
This is the logical follow-up to PR #9: grab the Docker image, extract `metabase.jar` from the image, and compare it (via SHA256 checksum) with the downloadable JAR from the website. This is to make sure that both JARs are exactly the same.

![image](https://user-images.githubusercontent.com/7288/124345132-c6f7d580-db8b-11eb-8d2e-5e16917790c8.png)

![image](https://user-images.githubusercontent.com/7288/124345154-fe668200-db8b-11eb-8e22-b0f7f0663f2f.png)
