### PR TITLE
Check the most recent EE and OSS JARs from GitHub releases

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,97 @@
+name: GitHub Releases Check
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+
+jobs:
+
+  release-ee:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 5
+    steps:
+    - name: Get the most recent metabase.jar (EE) from GitHub releases
+      run: |
+        curl -Lo releases.html https://github.com/metabase/metabase/releases
+        EE_JAR_URL=`grep 'metabase.jar' releases.html | grep enterprise | grep -oEi 'https://([a-z0-9A-Z\./\-]*\.jar)' | head -n1`
+        echo $EE_JAR_URL > url.txt
+        echo "----- Downloading JAR from $EE_JAR_URL -----"
+        curl -OL $EE_JAR_URL
+        stat ./metabase.jar
+        date | tee timestamp
+    - name: Reveal its version.properties
+      run: jar xf metabase.jar version.properties && cat version.properties
+    - name: Calculate SHA256 checksum
+      run: sha256sum ./metabase.jar | tee SHA256.sum
+    - name: Upload JAR as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: metabase-jar-ee
+        path: |
+          ./metabase.jar
+          ./url.txt
+          ./timestamp
+          ./SHA256.sum
+
+  release-oss:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 5
+    steps:
+    - name: Get the most recent metabase.jar (OSS) from GitHub releases
+      run: |
+        curl -Lo releases.html https://github.com/metabase/metabase/releases
+        OSS_JAR_URL=`grep 'metabase.jar' releases.html | grep -v enterprise | grep -oEi 'https://([a-z0-9A-Z\./\-]*\.jar)' | head -n1`
+        echo $OSS_JAR_URL > url.txt
+        echo "----- Downloading JAR from $OSS_JAR_URL -----"
+        curl -OL $OSS_JAR_URL
+        stat ./metabase.jar
+        date | tee timestamp
+    - name: Reveal its version.properties
+      run: jar xf metabase.jar version.properties && cat version.properties
+    - name: Calculate SHA256 checksum
+      run: sha256sum ./metabase.jar | tee SHA256.sum
+    - name: Upload JAR as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: metabase-jar-oss
+        path: |
+          ./metabase.jar
+          ./url.txt
+          ./timestamp
+          ./SHA256.sum
+
+  check-release:
+    runs-on: ubuntu-20.04
+    name: check ${{ matrix.edition }} (java ${{ matrix.java-version }})
+    needs: [release-ee, release-oss]
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        edition: [oss, ee]
+        java-version: [8, 11]
+    steps:
+    - name: Prepare JRE (Java Run-time Environment)
+      uses: actions/setup-java@v1
+      with:
+        java-package: jre
+        java-version: ${{ matrix.java-version }}
+    - run: java -version
+    - uses: actions/download-artifact@v2
+      name: Retrieve previously prepared JAR
+      with:
+        name: metabase-jar-${{ matrix.edition }}
+    - name: Show its version.properties
+      run: jar xf metabase.jar version.properties && cat version.properties
+    - name: Display when and where it was downloaded
+      run: |
+        cat timestamp
+        cat url.txt
+    - name: Show the checksum
+      run: cat SHA256.sum
+    - name: Launch the JAR (and keep it running)
+      run: java -jar ./metabase.jar &
+    - name: Wait for Metabase to start
+      run: while ! curl -s localhost:3000/api/health; do sleep 1; done
+      timeout-minutes: 3
+    - name: Check API health
+      run: curl -s localhost:3000/api/health


### PR DESCRIPTION
This adds a new Action which looks like:

![image](https://user-images.githubusercontent.com/7288/124777538-21c75f00-def5-11eb-9523-d3cf05159f95.png)

Examples of its checking log:

![image](https://user-images.githubusercontent.com/7288/124777582-2c81f400-def5-11eb-8d36-e11a526a53f3.png)
![image](https://user-images.githubusercontent.com/7288/124777611-3146a800-def5-11eb-8770-3fa7eecbb564.png)
