### PR TITLE
Sanity check: ensure that Mac DMG is properly downloadable

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,4 +1,4 @@
-name: JAR Sanity Check
+name: JAR, Docker, and Mac app Sanity Check
 
 on:
   schedule:
@@ -97,3 +97,19 @@ jobs:
       timeout-minutes: 1
     - name: Check API health
       run: curl -s localhost:3000/api/health
+
+  check-macapp-dmg:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 5
+    steps:
+    - name: Get Metabase.dmg from Metabase website
+      run: |
+        curl -o download.html https://www.metabase.com/start/oss/mac.html
+        DMG_DOWNLOAD_URL=`grep 'meta http-equiv="refresh"' download.html | grep -oEi 'https://([a-z0-9A-Z\./]*\.dmg)'`
+        echo $DMG_DOWNLOAD_URL > url.txt
+        echo "----- Downloading DMG from $DMG_DOWNLOAD_URL -----"
+        curl -OL $DMG_DOWNLOAD_URL
+        stat ./Metabase.dmg
+        date | tee timestamp
+    - name: Calculate SHA256 checksum
+      run: sha256sum ./Metabase.dmg | tee SHA256.sum


### PR DESCRIPTION
There will be this addition to the GitHub Action workflow:

![image](https://user-images.githubusercontent.com/7288/131563657-c127e947-d3a6-48e1-a3ba-e5928eb0e737.png)

Note: expect a follow-up to verify the DMG contents (for consistency checks etc) as soon as I figure out how to have it mounted.
