### PR TITLE
Mac app check: verify the uberjar inside the image

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -100,8 +100,14 @@ jobs:
 
   check-macapp-dmg:
     runs-on: ubuntu-20.04
+    needs: download
     timeout-minutes: 5
     steps:
+    - uses: actions/download-artifact@v2
+      name: Retrieve the checksum of previously downloaded JAR
+      with:
+        name: metabase-jar
+        path: download
     - name: Get Metabase.dmg from Metabase website
       run: |
         curl -o download.html https://www.metabase.com/start/oss/mac.html
@@ -113,3 +119,15 @@ jobs:
         date | tee timestamp
     - name: Calculate SHA256 checksum
       run: sha256sum ./Metabase.dmg | tee SHA256.sum
+    - run: sudo apt install -y dmg2img
+    - run: dmg2img Metabase.dmg Metabase.img
+    - name: Extract the contents
+      run: 7z x ./Metabase.img
+    - name: Grab metabase.jar from the image
+      run: cp ./Metabase/Metabase.app/Contents/Resources/metabase.jar .
+    - name: Show its version.properties
+      run: jar xf metabase.jar version.properties && cat version.properties
+    - name: Compare it with the downloaded JAR from the website
+      run: |
+        cp download/SHA256.sum .
+        sha256sum -c SHA256.sum


### PR DESCRIPTION
This ensures that the JAR inside that Mac app's DMG is actually the same as the downloadable JAR.

![image](https://user-images.githubusercontent.com/7288/131716652-c8acb837-4ebd-4091-a8cf-bb2fcbcd4f11.png)
