### PR TITLE
Sanity checks: also test with Java 17

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       matrix:
         edition: [oss, ee]
-        java-version: [8, 11]
+        java-version: [8, 11, 17]
     steps:
     - name: Prepare JRE (Java Run-time Environment)
       uses: actions/setup-java@v1

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        java-version: [8, 11]
+        java-version: [8, 11, 17]
     steps:
     - name: Prepare JRE (Java Run-time Environment)
       uses: actions/setup-java@v1


### PR DESCRIPTION
JDK 17 has been available since Sep 2021: https://openjdk.java.net/projects/jdk/17/.