### PR TITLE
Add scripts starting mongod requiring SSL

### DIFF
--- a/dbs/mongo/4.0/Dockerfile
+++ b/dbs/mongo/4.0/Dockerfile
@@ -13,6 +13,8 @@ COPY data/load.sh /docker-entrypoint-initdb.d/
 # in the image so that they can be pulled from them for local testing.
 COPY certificates/metabase.* certificates/metamongo.* certificates/metaca.* /etc/mongo/
 
+COPY 4.0/mongo-with-ssl.sh /bin/
+
 # In order to have an image with pre-populated data, we override the db path
 RUN mkdir /data/db2/ \
     && chown -R mongodb:mongodb /data/db2

--- a/dbs/mongo/4.0/mongo-with-ssl.sh
+++ b/dbs/mongo/4.0/mongo-with-ssl.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt

--- a/dbs/mongo/5.0/Dockerfile
+++ b/dbs/mongo/5.0/Dockerfile
@@ -13,6 +13,8 @@ COPY data/load.sh /docker-entrypoint-initdb.d/
 # in the image so that they can be pulled from them for local testing.
 COPY certificates/metabase.* certificates/metamongo.* certificates/metaca.* /etc/mongo/
 
+COPY 5.0/mongo-with-ssl.sh /bin/
+
 # In order to have an image with pre-populated data, we override the db path
 RUN mkdir /data/db2/ \
     && chown -R mongodb:mongodb /data/db2

--- a/dbs/mongo/5.0/mongo-with-ssl.sh
+++ b/dbs/mongo/5.0/mongo-with-ssl.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt


### PR DESCRIPTION
These scripts can be used by providing --entrypoint /bin/mongo-with-ssl.sh in the docker run command.