### PR TITLE
Add missing privilege for metabase user

### DIFF
--- a/dbs/oracle/user.sql
+++ b/dbs/oracle/user.sql
@@ -1,2 +1,3 @@
 create user metabase identified externally as 'CN=metabase,C=US';
 grant all privileges to metabase container = all;
+grant select on dba_users to metabase container = all;


### PR DESCRIPTION
During testing the framework needs to read the `dba_users` table and this requires a specific object privilege.