### PR TITLE
Force bash shell in mongo build

### DIFF
--- a/dbs/mongo/build.sh
+++ b/dbs/mongo/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Builds (and for now pushes) all Mongo images
 


### PR DESCRIPTION
Fixes #24

Checking versions with a wildcard is much more difficult in a strict POSIX shell.